### PR TITLE
checkboxes in time line chart "absolute" time -> "relative" time to the first action

### DIFF
--- a/vis/helpersFunctions/TimeLineChart.ipynb
+++ b/vis/helpersFunctions/TimeLineChart.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "***absoluteToRelativeTime* function** give the relative time compare to the first value time\n",
+    "* Input :  timeList > list of time\n",
+    "* Output :  relativeTimeList > list of relative time in minutes"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "def absoluteToRelativeTime(timeList):\n",
+    "    startTime=timeList[0]\n",
+    "    relativeTimeList=[]\n",
+    "    for time in timeList:\n",
+    "        t=time-startTime\n",
+    "        relativeTimeList.append(t.total_seconds()/60.0)\n",
+    "    return relativeTimeList"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/vis/xAPISG-CompletableProgressIncreaseDecrease.ipynb
+++ b/vis/xAPISG-CompletableProgressIncreaseDecrease.ipynb
@@ -1,18 +1,56 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
    "metadata": {
     "collapsed": true,
     "pycharm": {
-     "name": "#%% md\n"
+     "name": "#%%\n"
     }
    },
+   "source": [
+    "%run vis/xAPISG-noDataToFillVisualization.ipynb # notebook to create the visualisation with a message NoDataToFill\n",
+    "%run vis/helpersFunctions/TimeLineChart.ipynb"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Selectors :\n",
+    "   * absoluteToRelativeCompletableProgress : checkboxe (T/F) value to display the line chart per relative time"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#constructing a checkboxe to view chart per relative time\n",
+    "absoluteToRelativeCompletableProgress=widgets.Checkbox(value=False,\n",
+    "                                        description='View in relative time')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "***vis_completables_progress_increase_decrease* function**:\n",
     "* Output : the outputCompletableProgress in a list to be display in a VBox\n",
     "* outputCompletableProgressIncreaseDecrease : display a points/line chart showing for each player in function of time the progress increase or decrease of different completables of the game"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",
@@ -25,8 +63,9 @@
     "            clear_output(wait=False)\n",
     "            getProgressPlayerIncreaseDecreasePerCompletable()\n",
     "            clear_output(wait=True)\n",
+    "    absoluteToRelativeCompletableProgress.observe(display_completable_progress_increase_decrease,'value')\n",
     "    display_completable_progress_increase_decrease(None)\n",
-    "    return [outputCompletableProgressIncreaseDecreaseUpdate, outputCompletableProgressIncreaseDecrease]"
+    "    return [absoluteToRelativeCompletableProgress, outputCompletableProgressIncreaseDecreaseUpdate, outputCompletableProgressIncreaseDecrease]"
    ],
    "metadata": {
     "collapsed": false,
@@ -99,14 +138,17 @@
     "                                    previousval+=value\n",
     "                                    completableProgressIncreaseDecrease[player][key]=previousval\n",
     "                                i+=1\n",
-    "                    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S %d-%m-%y'))\n",
-    "                    locator= mdates.MinuteLocator(interval=10)\n",
-    "                    locator.MAXTICKS=40000\n",
-    "                    plt.gca().xaxis.set_major_locator(locator)\n",
     "                    for player in completableProgressIncreaseDecrease.keys():\n",
     "                        # one line chart per player showing progress over time\n",
     "                        y = list(completableProgressIncreaseDecrease[player].values())\n",
-    "                        x = list(completableProgressIncreaseDecrease[player].keys())\n",
+    "                        if absoluteToRelativeCompletableProgress.value:\n",
+    "                            x = absoluteToRelativeTime(list(completableProgressIncreaseDecrease[player].keys()))\n",
+    "                        else:\n",
+    "                            plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S %d-%m-%y'))\n",
+    "                            locator=mdates.MinuteLocator(interval=10)\n",
+    "                            locator.MAXTICKS=40000\n",
+    "                            plt.gca().xaxis.set_major_locator(locator)\n",
+    "                            x = list(completableProgressIncreaseDecrease[player].keys())\n",
     "                        plt.scatter(x,y, label=player)\n",
     "                        plt.plot(x,y)\n",
     "                    #legend graph and give a date format\n",
@@ -114,7 +156,10 @@
     "                    #orient xticks\n",
     "                    plt.xticks(rotation=45, ha=\"right\")\n",
     "                    #display title and labels\n",
-    "                    plt.xlabel(\"Time\")\n",
+    "                    if absoluteToRelativeCompletableProgress.value:\n",
+    "                        plt.xlabel('Time (in minutes)')\n",
+    "                    else:\n",
+    "                        plt.xlabel('Date')\n",
     "                    plt.ylabel(\"Progress increase/decrease\")\n",
     "                    plt.title(\"Progress increase/decrease of players for \"+completable)\n",
     "        plt.show()\n",

--- a/vis/xAPISG-PlayersProgress.ipynb
+++ b/vis/xAPISG-PlayersProgress.ipynb
@@ -5,7 +5,34 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "%run vis/xAPISG-noDataToFillVisualization.ipynb # notebook to create the visualisation with a message NoDataToFill"
+    "%run vis/xAPISG-noDataToFillVisualization.ipynb # notebook to create the visualisation with a message NoDataToFill\n",
+    "%run vis/helpersFunctions/TimeLineChart.ipynb"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Selectors :\n",
+    "   * absoluteToRelativePlayerProgress : checkboxe (T/F) value to display the line chart per relative time"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#constructing a checkboxe to view chart per relative time\n",
+    "absoluteToRelativePlayerProgress=widgets.Checkbox(value=False,\n",
+    "                                        description='View in relative time')"
    ],
    "metadata": {
     "collapsed": false,
@@ -30,11 +57,14 @@
    "outputs": [],
    "source": [
     "def vis_players_progress():\n",
-    "    with outputPlayerProgress:\n",
-    "        clear_output(wait=False)\n",
-    "        players_progress()\n",
-    "        clear_output(wait=True)\n",
-    "    return [outputPlayerProgressUpdate, outputPlayerProgress]"
+    "    def display_player_progress(change):\n",
+    "        with outputPlayerProgress:\n",
+    "            clear_output(wait=False)\n",
+    "            players_progress()\n",
+    "            clear_output(wait=True)\n",
+    "    absoluteToRelativePlayerProgress.observe(display_player_progress, 'value')\n",
+    "    display_player_progress(None)\n",
+    "    return [absoluteToRelativePlayerProgress, outputPlayerProgressUpdate, outputPlayerProgress]"
    ]
   },
   {
@@ -72,14 +102,19 @@
     "                #list of time and progress value\n",
     "                progress_time = list(zip(*players_info[player][\"game_progress_per_time\"]))\n",
     "                y = [i*100 for i in progress_time[0]]\n",
-    "                x = progress_time[1]\n",
+    "                if absoluteToRelativePlayerProgress.value:\n",
+    "                    x = absoluteToRelativeTime(progress_time[1])\n",
+    "                    plt.xlabel('Time (in minutes)')\n",
+    "                else:\n",
+    "                    plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S %d-%m-%y'))\n",
+    "                    plt.gca().xaxis.set_major_locator(mdates.MinuteLocator(interval=5))\n",
+    "                    x =progress_time[1]\n",
+    "                    plt.xlabel('Date')\n",
     "                plt.plot(x,y, label=player) # one line chart per player showing progress over time\n",
     "                empty=False\n",
     "    if not empty:\n",
     "        #legend graph and give a date format\n",
     "        plt.legend(loc='center left', bbox_to_anchor=(1, 0.5))\n",
-    "        plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S %d-%m-%y'))\n",
-    "        plt.gca().xaxis.set_major_locator(mdates.MinuteLocator(interval=5))\n",
     "        plt.yticks(np.arange(0,101,10))\n",
     "    else:\n",
     "        #display not data to fill vis\n",
@@ -87,9 +122,12 @@
     "    #orient xticks\n",
     "    plt.xticks(rotation=45, ha=\"right\")\n",
     "    #add title and axes labels\n",
+    "    if absoluteToRelativePlayerProgress.value:\n",
+    "        plt.xlabel('Time (in minutes)')\n",
+    "    else:\n",
+    "        plt.xlabel('Date')\n",
     "    plt.title(\"Progress (in %) of players by time\")\n",
     "    plt.ylabel('Progress (in %)')\n",
-    "    plt.xlabel('Date')\n",
     "    plt.show()\n",
     "    with outputPlayerProgressUpdate:\n",
     "        clear_output(wait=False)"


### PR DESCRIPTION
checkboxes in time line chart instead of "absolute" time -> "relative to the first action" (relative to the start and showed 30min, 1h etc of playing time) with time in minutes